### PR TITLE
refactor: introduce streamwriter

### DIFF
--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use clap::{Parser, Subcommand};
 use clap_stdin::MaybeStdin;
 use gn::StreamWriter;
-use tokio::{io::AsyncReadExt, net::TcpListener, time::Instant};
+use tokio::{io::AsyncReadExt, net::TcpListener};
 
 #[derive(Parser)]
 struct App {
@@ -49,10 +49,11 @@ async fn main() -> gn::Result<()> {
             count,
             duration,
         } => {
-            let _start = Instant::now();
             let mut writer = StreamWriter::new(host, input.as_bytes(), count, duration);
             let wrote = writer.write().await.unwrap();
+            let throughput = writer.throughput();
             writeln!(out, "Wrote {wrote} bytes").unwrap();
+            writeln!(out, "Bytes per second {throughput}").unwrap();
         }
         Commands::Serve { address } => {
             let bind = TcpListener::bind(address).await?;

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -3,12 +3,8 @@ use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
 use clap_stdin::MaybeStdin;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream}, time::Instant,
-};
-
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+use gn::StreamWriter;
+use tokio::{io::AsyncReadExt, net::TcpListener, time::Instant};
 
 #[derive(Parser)]
 struct App {
@@ -43,21 +39,19 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> gn::Result<()> {
     let mut out = std::io::stderr().lock();
 
     match App::parse().cmds {
-        Commands::Write { input, host, count, duration: _ } => {
-            let start = Instant::now();
-            let mut wrote: u64 = 0;
-            for _ in 0..count {
-                let mut stream = TcpStream::connect(host).await?;
-                let input = input.as_bytes();
-                stream.write_all(input).await?;
-                wrote += input.len() as u64;
-            }
-            let elapsed = start.elapsed().as_secs();
-            let _throughput = wrote / elapsed;
+        Commands::Write {
+            input,
+            host,
+            count,
+            duration,
+        } => {
+            let _start = Instant::now();
+            let mut writer = StreamWriter::new(host, input.as_bytes(), count, duration);
+            let wrote = writer.write().await.unwrap();
             writeln!(out, "Wrote {wrote} bytes").unwrap();
         }
         Commands::Serve { address } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+mod writer;
+
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub use writer::StreamWriter;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,9 +1,6 @@
 use std::net::ToSocketAddrs;
 
-use tokio::{
-    io::AsyncWriteExt,
-    net::TcpStream,
-};
+use tokio::{io::AsyncWriteExt, net::TcpStream, time::Instant};
 
 pub struct StreamWriter<'a, S: ToSocketAddrs> {
     host: S,
@@ -11,6 +8,8 @@ pub struct StreamWriter<'a, S: ToSocketAddrs> {
 
     count: u64,
     bytes_written: u64,
+    throughput: f64,
+    #[allow(dead_code)]
     duration: Option<humantime::Duration>,
 }
 
@@ -30,14 +29,22 @@ where
             count,
             duration,
             bytes_written: 0,
+            throughput: 0.0,
         }
     }
 
+    /// Write to the provided host(s), returning the total number of bytes written.
+    /// At the same time, this also calculated the throughput for total number
+    /// of bytes sent per second.
+    ///
+    /// NOTE: Owing to truncation to seconds, the produced throughput may not
+    /// be accurate for low write counts.
     pub async fn write(&mut self) -> crate::Result<u64> {
         let addrs = self
             .host
             .to_socket_addrs()
             .expect("Valid socket addresses are provided");
+        let start = Instant::now();
         for addr in addrs {
             for _ in 0..self.count {
                 let mut stream = TcpStream::connect(addr).await?;
@@ -45,6 +52,18 @@ where
                 self.bytes_written += self.input.len() as u64;
             }
         }
+
+        self.throughput = self.bytes_written as f64 / start.elapsed().as_secs() as f64;
+
         Ok(self.bytes_written)
+    }
+
+    /// Retrieve the perceived bytes per second throughput that was written to
+    /// the TCP sockets.
+    ///
+    /// NOTE: Owing to truncation to seconds, the produced throughput may not
+    /// be accurate for low write counts.
+    pub fn throughput(&self) -> f64 {
+        self.throughput
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,50 @@
+use std::net::ToSocketAddrs;
+
+use tokio::{
+    io::AsyncWriteExt,
+    net::TcpStream,
+};
+
+pub struct StreamWriter<'a, S: ToSocketAddrs> {
+    host: S,
+    input: &'a [u8],
+
+    count: u64,
+    bytes_written: u64,
+    duration: Option<humantime::Duration>,
+}
+
+impl<'a, S> StreamWriter<'a, S>
+where
+    S: ToSocketAddrs,
+{
+    pub fn new(
+        host: S,
+        input: &'a [u8],
+        count: u64,
+        duration: Option<humantime::Duration>,
+    ) -> Self {
+        Self {
+            host,
+            input,
+            count,
+            duration,
+            bytes_written: 0,
+        }
+    }
+
+    pub async fn write(&mut self) -> crate::Result<u64> {
+        let addrs = self
+            .host
+            .to_socket_addrs()
+            .expect("Valid socket addresses are provided");
+        for addr in addrs {
+            for _ in 0..self.count {
+                let mut stream = TcpStream::connect(addr).await?;
+                stream.write_all(self.input).await?;
+                self.bytes_written += self.input.len() as u64;
+            }
+        }
+        Ok(self.bytes_written)
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -34,11 +34,11 @@ where
     }
 
     /// Write to the provided host(s), returning the total number of bytes written.
-    /// At the same time, this also calculated the throughput for total number
+    /// At the same time, this also calculates the throughput for total number
     /// of bytes sent per second.
     ///
-    /// NOTE: Owing to truncation to seconds, the produced throughput may not
-    /// be accurate for low write counts.
+    /// NOTE: Owing to truncation from nanosecond precision to seconds, the
+    /// produced throughput may not be accurate for low write counts.
     pub async fn write(&mut self) -> crate::Result<u64> {
         let addrs = self
             .host
@@ -61,8 +61,8 @@ where
     /// Retrieve the perceived bytes per second throughput that was written to
     /// the TCP sockets.
     ///
-    /// NOTE: Owing to truncation to seconds, the produced throughput may not
-    /// be accurate for low write counts.
+    /// NOTE: Owing to truncation from nanosecond precision to seconds, the
+    /// produced throughput may not be accurate for low write counts.
     pub fn throughput(&self) -> f64 {
         self.throughput
     }


### PR DESCRIPTION
Introduce a `StreamWriter` to handle the responsibilities of connecting to a TCP socket, to write a stream of bytes.

This also calculates some miscellaneous information around the data written - which can be expanded later.