### PR TITLE
feat: write for duration

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,10 +1,11 @@
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
 
 use tokio::{io::AsyncWriteExt, net::TcpStream, time::Instant};
 
 pub struct StreamWriter<'a, S: ToSocketAddrs> {
     host: S,
     input: &'a [u8],
+    input_size: u64,
 
     count: u64,
     bytes_written: u64,
@@ -26,6 +27,7 @@ where
         Self {
             host,
             input,
+            input_size: input.len() as u64,
             count,
             duration,
             bytes_written: 0,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,4 +1,4 @@
-use std::{net::ToSocketAddrs, time::Duration};
+use std::net::ToSocketAddrs;
 
 use tokio::{io::AsyncWriteExt, net::TcpStream, time::Instant};
 
@@ -46,22 +46,22 @@ where
             .expect("Valid socket addresses are provided");
         let start = Instant::now();
         for addr in addrs {
-            let mut stream = TcpStream::connect(addr).await?;
             match self.duration {
                 Some(duration) => {
                     let for_duration = Instant::now();
-                    let mut interval = tokio::time::interval(Duration::from_millis(100));
                     loop {
-                        interval.tick().await;
-                        if for_duration.elapsed() > *duration {
+                        if for_duration.elapsed() >= *duration {
                             break;
                         } else {
+                            let mut stream = TcpStream::connect(addr).await?;
                             stream.write_all(self.input).await?;
+                            self.bytes_written += self.input.len() as u64;
                         }
                     }
                 }
                 None => {
                     for _ in 0..self.count {
+                        let mut stream = TcpStream::connect(addr).await?;
                         stream.write_all(self.input).await?;
                         self.bytes_written += self.input.len() as u64;
                     }


### PR DESCRIPTION
Closes https://github.com/jdockerty/gn/issues/3

Uses `humantime` to write for a particular duration, taking precedence over `count`.