### PR TITLE
feat: add writeopts enum

### DIFF
--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -27,6 +27,11 @@ enum Commands {
         #[clap(short, long, default_value = "1")]
         count: u64,
 
+        /// The duration of time to write for, e.g. 30s
+        ///
+        /// When provided alongside `count`, whichever comes first will then halt
+        /// writes. For example, duration=40s and count=10, the count is in almost
+        /// every case going to be reached first.
         #[clap(short, long)]
         duration: Option<humantime::Duration>,
     },

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -48,10 +48,7 @@ async fn main() -> gn::Result<()> {
             count,
             duration,
         } => {
-            let opts = match duration {
-                Some(d) => WriteOptions::Duration(d),
-                None => WriteOptions::Count(count),
-            };
+            let opts = WriteOptions::from_flags(count, duration);
             let mut writer = StreamWriter::new(host, input.as_bytes(), opts);
             let wrote = writer.write().await?;
             let throughput = writer.throughput();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod writer;
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub use server::Server;
-pub use writer::StreamWriter;
+pub use writer::{StreamWriter, WriteOptions};

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -94,7 +94,7 @@ mod test {
 
     use humantime::Duration;
 
-    use crate::StreamWriter;
+    use crate::{writer::WriteOptions, StreamWriter};
 
     #[tokio::test]
     async fn write() {
@@ -102,10 +102,18 @@ mod test {
 
         let input = b"hello";
         let size = input.len() as u64;
-        let mut s = StreamWriter::new(listener.local_addr().unwrap(), input, 1, None);
+        let mut s = StreamWriter::new(
+            listener.local_addr().unwrap(),
+            input,
+            WriteOptions::Count(1),
+        );
         assert_eq!(s.write().await.unwrap(), size);
 
-        let mut s = StreamWriter::new(listener.local_addr().unwrap(), input, 5, None);
+        let mut s = StreamWriter::new(
+            listener.local_addr().unwrap(),
+            input,
+            WriteOptions::Count(5),
+        );
         assert_eq!(
             s.write().await.unwrap(),
             size * 5,
@@ -119,7 +127,11 @@ mod test {
 
         let input = b"duration_write";
         let duration = Duration::from_str("2s").unwrap();
-        let mut s = StreamWriter::new(listener.local_addr().unwrap(), input, 1, Some(duration));
+        let mut s = StreamWriter::new(
+            listener.local_addr().unwrap(),
+            input,
+            WriteOptions::Duration(duration),
+        );
 
         let start = Instant::now();
         s.write().await.unwrap();
@@ -131,7 +143,11 @@ mod test {
     async fn throughput() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
 
-        let mut s = StreamWriter::new(listener.local_addr().unwrap(), b"a", 100, None);
+        let mut s = StreamWriter::new(
+            listener.local_addr().unwrap(),
+            b"a",
+            WriteOptions::Count(100),
+        );
         s.write().await.unwrap();
         assert!(
             s.throughput() != 0.0,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -118,9 +118,14 @@ mod test {
     }
 
     write_options!(
-        from_flags_count,
+        from_flags_default_count,
         opts = WriteOptions::from_flags(1, None),
         expected = WriteOptions::Count(1)
+    );
+    write_options!(
+        from_flags_non_default_count,
+        opts = WriteOptions::from_flags(100_000_000, None),
+        expected = WriteOptions::Count(100_000_000)
     );
     write_options!(
         from_flags_duration,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -81,7 +81,18 @@ where
                         }
                     }
                 }
-                WriteOptions::CountOrDuration(_count, _duration) => unimplemented!(),
+                WriteOptions::CountOrDuration(count, duration) => {
+                    let for_duration = Instant::now();
+                    let mut sent = 0;
+                    loop {
+                        if sent == count || for_duration.elapsed() >= *duration {
+                            break;
+                        } else {
+                            self.write_stream(addr).await?;
+                            sent += 1;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,13 +2,20 @@ use std::net::{SocketAddr, ToSocketAddrs};
 
 use tokio::{io::AsyncWriteExt, net::TcpStream, time::Instant};
 
+/// Desired behaviour for how a socket should be written to.
 pub enum WriteOptions {
+    /// Write a `u64` number of streams.
     Count(u64),
+    /// Write for a `Duration` length of time.
     Duration(humantime::Duration),
+    /// Write a `u64` number of streams or write for a `Duration` length of time,
+    /// whichever comes first.
     CountOrDuration(u64, humantime::Duration),
 }
 
 impl WriteOptions {
+    /// Create [`WriteOptions`] from the known flags of the application which
+    /// influence the behaviour of writes.
     pub fn from_flags(count: u64, duration: Option<humantime::Duration>) -> Self {
         match duration {
             Some(d) if count > 1 => WriteOptions::CountOrDuration(count, d),


### PR DESCRIPTION
Adds a `WriteOptions` enum to encode the given behaviours for how a stream should be written to.
