### PR TITLE
feat: add concurrency flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +271,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap-stdin",
+ "futures",
  "humantime",
  "tokio",
 ]
@@ -292,6 +382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.16", features = ["derive"] }
 clap-stdin = { version = "0.5.1", features = ["tokio"] }
+futures = "0.3.30"
 humantime = "2.1.0"
 tokio = { version = "1.39.3", features = ["net", "full"] }

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -34,6 +34,10 @@ enum Commands {
         /// every case going to be reached first.
         #[clap(short, long)]
         duration: Option<humantime::Duration>,
+
+        /// Number of concurrent requests to send.
+        #[clap(short, long)]
+        concurrency: Option<u64>,
     },
     /// Start a TCP server
     Serve {
@@ -52,8 +56,9 @@ async fn main() -> gn::Result<()> {
             host,
             count,
             duration,
+            concurrency,
         } => {
-            let opts = WriteOptions::from_flags(count, duration);
+            let opts = WriteOptions::from_flags(count, duration, concurrency);
             let mut writer = StreamWriter::new(host, input.as_bytes(), opts);
             let wrote = writer.write().await?;
             let throughput = writer.throughput();

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -36,7 +36,7 @@ enum Commands {
         duration: Option<humantime::Duration>,
 
         /// Number of concurrent requests to send.
-        #[clap(short, long)]
+        #[clap(long)]
         concurrency: Option<u64>,
     },
     /// Start a TCP server

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -3,6 +3,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use tokio::{io::AsyncWriteExt, net::TcpStream, time::Instant};
 
 /// Desired behaviour for how a socket should be written to.
+#[derive(Debug)]
 pub enum WriteOptions {
     /// Write a `u64` number of streams.
     Count(u64),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,6 @@
 use std::net::{SocketAddr, ToSocketAddrs};
 
+use futures::{stream::FuturesUnordered, StreamExt};
 use tokio::{io::AsyncWriteExt, net::TcpStream, time::Instant};
 
 /// Desired behaviour for how a socket should be written to.
@@ -14,6 +15,8 @@ pub enum WriteOptions {
     CountOrDuration(u64, humantime::Duration),
     /// Write a concurrent number of streams up to a particular count.
     ConcurrencyWithCount(u64, u64),
+    /// Write a concurrent number of streams for a set duration.
+    ConcurrencyWithDuration(u64, humantime::Duration),
 }
 
 impl WriteOptions {
@@ -28,7 +31,7 @@ impl WriteOptions {
             (Some(d), None) if count > 1 => WriteOptions::CountOrDuration(count, d),
             (Some(d), None) => WriteOptions::Duration(d),
             (None, Some(c)) => WriteOptions::ConcurrencyWithCount(c, count),
-            (Some(_d), Some(_c)) => todo!(),
+            (Some(d), Some(c)) => WriteOptions::ConcurrencyWithDuration(c, d),
             (None, None) => WriteOptions::Count(count),
         }
     }
@@ -113,6 +116,28 @@ where
                     }
                     for task in tasks {
                         self.bytes_written += task.await?;
+                    }
+                }
+                WriteOptions::ConcurrencyWithDuration(concurrency, duration) => {
+                    let mut futs = FuturesUnordered::new();
+                    for _ in 0..concurrency {
+                        let input = self.input.to_owned();
+                        let task = tokio::spawn(async move {
+                            let for_duration = Instant::now();
+                            let mut task_bytes = 0;
+                            loop {
+                                if for_duration.elapsed() >= *duration {
+                                    break;
+                                } else {
+                                    task_bytes += write_stream(addr, &input).await.unwrap();
+                                }
+                            }
+                            task_bytes
+                        });
+                        futs.push(task);
+                    }
+                    while let Some(task) = futs.next().await {
+                        self.bytes_written += task?;
                     }
                 }
             }
@@ -259,6 +284,37 @@ mod test {
         let mut s = StreamWriter::new(addr, input, WriteOptions::ConcurrencyWithCount(5, 100_000));
 
         assert_eq!(s.write().await.unwrap(), 100_000);
+        println!("Wrote {} bytes per second", s.throughput());
+    }
+
+    #[tokio::test]
+    async fn write_concurrency_with_duration() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                listener.accept().await.unwrap();
+            }
+        });
+
+        let input = b"concurrent_duration";
+        let duration = humantime::Duration::from_str("2s").unwrap();
+        let mut s = StreamWriter::new(
+            addr,
+            input,
+            WriteOptions::ConcurrencyWithDuration(10, duration),
+        );
+
+        let start = Instant::now();
+        s.write().await.unwrap();
+        let elapsed = start.elapsed().as_secs();
+        assert_eq!(elapsed, 2);
+        assert!(s.throughput() > 0.0);
+        assert!(
+            s.bytes_written > input.len() as u64 * 1000,
+            "More than 1000 requests should be sent"
+        );
         println!("Wrote {} bytes per second", s.throughput());
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -101,7 +101,7 @@ where
                     }
                 }
                 WriteOptions::ConcurrencyWithCount(concurrency, count) => {
-                    let mut tasks = Vec::new();
+                    let mut futs = FuturesUnordered::new();
                     let requests_per_task = count / concurrency;
                     for _ in 0..concurrency {
                         let input = self.input.to_owned();
@@ -112,10 +112,10 @@ where
                             }
                             task_bytes
                         });
-                        tasks.push(task);
+                        futs.push(task);
                     }
-                    for task in tasks {
-                        self.bytes_written += task.await?;
+                    while let Some(task) = futs.next().await {
+                        self.bytes_written += task?;
                     }
                 }
                 WriteOptions::ConcurrencyWithDuration(concurrency, duration) => {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,16 +11,24 @@ pub enum WriteOptions {
     /// Write a `u64` number of streams or write for a `Duration` length of time,
     /// whichever comes first.
     CountOrDuration(u64, humantime::Duration),
+    /// Write a concurrent number of streams up to a particular count.
+    ConcurrencyWithCount(u64, u64),
 }
 
 impl WriteOptions {
     /// Create [`WriteOptions`] from the known flags of the application which
     /// influence the behaviour of writes.
-    pub fn from_flags(count: u64, duration: Option<humantime::Duration>) -> Self {
-        match duration {
-            Some(d) if count > 1 => WriteOptions::CountOrDuration(count, d),
-            Some(d) => WriteOptions::Duration(d),
-            None => WriteOptions::Count(count),
+    pub fn from_flags(
+        count: u64,
+        duration: Option<humantime::Duration>,
+        concurrency: Option<u64>,
+    ) -> Self {
+        match (duration, concurrency) {
+            (Some(d), None) if count > 1 => WriteOptions::CountOrDuration(count, d),
+            (Some(d), None) => WriteOptions::Duration(d),
+            (None, Some(c)) => WriteOptions::ConcurrencyWithCount(c, count),
+            (Some(_d), Some(_c)) => todo!(),
+            (None, None) => WriteOptions::Count(count),
         }
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -208,6 +208,15 @@ mod test {
         opts = WriteOptions::from_flags(100, None, Some(10)),
         expected = WriteOptions::ConcurrencyWithCount(10, 100)
     );
+    write_options!(
+        from_flags_concurrency_duration,
+        opts = WriteOptions::from_flags(
+            1,
+            Some(humantime::Duration::from_str("10s").unwrap()),
+            Some(10)
+        ),
+        expected = WriteOptions::ConcurrencyWithDuration(10, _)
+    );
 
     /// Encompass the count variant of the write options into a macro for ease of
     /// use of testing various scenarios


### PR DESCRIPTION
Introduces a `--concurrency` flag which spawns multiple tokio tasks to write requests either for a specific maximum duration or number of requests - tying together the `--duration`/`--count` flags.