### PR TITLE
chore: rename `StreamWriter` to `SocketManager`

### DIFF
--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
 use clap_stdin::MaybeStdin;
-use gn::{Server, StreamWriter, WriteOptions};
+use gn::{Server, SocketManager, WriteOptions};
 
 #[derive(Parser)]
 struct App {
@@ -59,7 +59,7 @@ async fn main() -> gn::Result<()> {
             concurrency,
         } => {
             let opts = WriteOptions::from_flags(count, duration, concurrency);
-            let mut writer = StreamWriter::new(host, input.as_bytes(), opts);
+            let mut writer = SocketManager::new(host, input.as_bytes(), opts);
             let wrote = writer.write().await?;
             let throughput = writer.throughput();
             writeln!(out, "Wrote {wrote} bytes")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
+mod manager;
 mod server;
-mod writer;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+pub use manager::{SocketManager, WriteOptions};
 pub use server::Server;
-pub use writer::{SocketManager, WriteOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod writer;
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub use server::Server;
-pub use writer::{StreamWriter, WriteOptions};
+pub use writer::{SocketManager, WriteOptions};

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -170,7 +170,7 @@ mod test {
 
     use humantime::Duration;
 
-    use crate::{writer::WriteOptions, SocketManager};
+    use crate::{manager::WriteOptions, SocketManager};
 
     macro_rules! write_options {
         ($name:ident, opts = $opts:expr, expected = $expected:pat) => {


### PR DESCRIPTION
This is really managing the writing of sockets, not particular streams.

The underlying stream is once a socket is written to, but the functionality is sockets which will incidentally be written to at a later time. This also plays into https://github.com/jdockerty/gn/issues/9 as the socket may be either TCP or UDP at a later time.