### PR TITLE
feat: support udp

### DIFF
--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -46,6 +46,9 @@ enum Commands {
     Serve {
         #[arg(long, default_value = "127.0.0.1:5000")]
         address: SocketAddr,
+
+        #[arg(long, short, default_value = "tcp")]
+        protocol: Protocol,
     },
 }
 
@@ -69,8 +72,8 @@ async fn main() -> gn::Result<()> {
             writeln!(out, "Wrote {wrote} bytes")?;
             writeln!(out, "Bytes per second {throughput}")?;
         }
-        Commands::Serve { address } => {
-            let mut server = Server::new(address, out);
+        Commands::Serve { address, protocol } => {
+            let mut server = Server::new(address, protocol, out);
             server.serve().await?;
         }
     };

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
 use clap_stdin::MaybeStdin;
-use gn::{Server, SocketManager, WriteOptions};
+use gn::{Protocol, Server, SocketManager, WriteOptions};
 
 #[derive(Parser)]
 struct App {
@@ -17,6 +17,9 @@ enum Commands {
     Write {
         #[arg(long)]
         host: SocketAddr,
+
+        #[arg(long, short, default_value = "tcp")]
+        protocol: Protocol,
 
         /// Input data to be written to the TCP socket.
         ///
@@ -57,6 +60,7 @@ async fn main() -> gn::Result<()> {
             count,
             duration,
             concurrency,
+            protocol: _,
         } => {
             let opts = WriteOptions::from_flags(count, duration, concurrency);
             let mut writer = SocketManager::new(host, input.as_bytes(), opts);

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -60,10 +60,10 @@ async fn main() -> gn::Result<()> {
             count,
             duration,
             concurrency,
-            protocol: _,
+            protocol,
         } => {
             let opts = WriteOptions::from_flags(count, duration, concurrency);
-            let mut writer = SocketManager::new(host, input.as_bytes(), opts);
+            let mut writer = SocketManager::new(host, input.as_bytes(), protocol, opts);
             let wrote = writer.write().await?;
             let throughput = writer.throughput();
             writeln!(out, "Wrote {wrote} bytes")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 mod manager;
+mod protocol;
 mod server;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub use manager::{SocketManager, WriteOptions};
+pub use protocol::Protocol;
 pub use server::Server;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -419,16 +419,19 @@ mod test {
         println!("Wrote {} bytes per second", s.throughput());
     }
 
-    #[tokio::test]
-    async fn throughput() {
-        let protocol = Protocol::Tcp;
+    async fn throughput_helper(protocol: Protocol) {
         let addr = bind_socket(&protocol).await;
-
-        let mut s = SocketManager::new(addr, b"a", protocol, WriteOptions::Count(100));
+        let mut s = SocketManager::new(addr, b"a", protocol.clone(), WriteOptions::Count(100));
         s.write().await.unwrap();
         assert!(
             s.throughput() != 0.0,
-            "Throughput should be set after writing data"
+            "Throughput should be set after writing {protocol} data"
         );
+    }
+
+    #[tokio::test]
+    async fn throughput() {
+        throughput_helper(Protocol::Tcp).await;
+        throughput_helper(Protocol::Udp).await;
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,18 @@
+use clap::ValueEnum;
+
+#[derive(Default, Clone, ValueEnum)]
+pub enum Protocol {
+    #[default]
+    Tcp,
+    Udp,
+}
+
+impl From<&str> for Protocol {
+    fn from(value: &str) -> Self {
+        match value {
+            "tcp" | "TCP" => Self::Tcp,
+            "udp" | "UDP" => Self::Udp,
+            _ => panic!("unsupported connection type: {value}"),
+        }
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use clap::ValueEnum;
 
 #[derive(Default, Clone, ValueEnum)]
@@ -13,6 +15,15 @@ impl From<&str> for Protocol {
             "tcp" | "TCP" => Self::Tcp,
             "udp" | "UDP" => Self::Udp,
             _ => panic!("unsupported connection type: {value}"),
+        }
+    }
+}
+
+impl Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp => write!(f, "tcp"),
+            Self::Udp => write!(f, "udp"),
         }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -14,7 +14,7 @@ impl From<&str> for Protocol {
         match value {
             "tcp" | "TCP" => Self::Tcp,
             "udp" | "UDP" => Self::Udp,
-            _ => panic!("unsupported connection type: {value}"),
+            _ => panic!("unsupported protocol: {value}"),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,15 @@
 use std::{io::Write, net::SocketAddr};
 
-use tokio::{io::AsyncReadExt, net::TcpListener};
+use tokio::{
+    io::AsyncReadExt,
+    net::{TcpListener, UdpSocket},
+};
+
+use crate::Protocol;
 
 pub struct Server<W: Write> {
     addr: SocketAddr,
+    protocol: Protocol,
 
     /// Buffer for data to be written too. This buffer sink is for the actual
     /// data that is being sent and _not_ included with log lines.
@@ -11,19 +17,37 @@ pub struct Server<W: Write> {
 }
 
 impl<W: Write> Server<W> {
-    pub fn new(addr: SocketAddr, buffer: W) -> Self {
-        Self { addr, buffer }
+    pub fn new(addr: SocketAddr, protocol: Protocol, buffer: W) -> Self {
+        Self {
+            addr,
+            protocol,
+            buffer,
+        }
     }
 
     pub async fn serve(&mut self) -> crate::Result<()> {
-        let bind = TcpListener::bind(self.addr).await?;
-        eprintln!("Listening on tcp://{}", bind.local_addr()?);
+        match self.protocol {
+            Protocol::Tcp => {
+                let bind = TcpListener::bind(self.addr).await?;
+                eprintln!("Listening on tcp://{}", bind.local_addr()?);
 
-        while let Ok((mut stream, _addr)) = bind.accept().await {
-            let mut s = String::new();
-            match stream.read_to_string(&mut s).await {
-                Ok(_) => writeln!(self.buffer, "{s}")?,
-                Err(e) => eprintln!("Unable to read stream: {e}"),
+                while let Ok((mut stream, _addr)) = bind.accept().await {
+                    let mut s = String::new();
+                    match stream.read_to_string(&mut s).await {
+                        Ok(_) => writeln!(self.buffer, "{s}")?,
+                        Err(e) => eprintln!("Unable to read stream: {e}"),
+                    }
+                }
+            }
+            Protocol::Udp => {
+                let bind = UdpSocket::bind(self.addr).await?;
+                eprintln!("Listening on udp://{}", bind.local_addr()?);
+                loop {
+                    let mut buf = [0; 1024];
+                    while let Ok((len, _addr)) = bind.recv_from(&mut buf).await {
+                        writeln!(self.buffer, "{}", String::from_utf8_lossy(&buf[0..len]))?;
+                    }
+                }
             }
         }
         unreachable!("This is a blocking call");


### PR DESCRIPTION
Closes https://github.com/jdockerty/gn/issues/9

- Adds a `--protocol tcp|udp` flag.
- Capture protocols via `Protocol` enum.
- Introduces a UDP server binding on the `serve` subcommand.
- Write UDP data via `write` subcommand.
- Expand tests