### PR TITLE
refactor: genericise write for duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic_float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +275,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 name = "gn"
 version = "0.1.0"
 dependencies = [
+ "atomic_float",
  "clap",
  "clap-stdin",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Jack Dockerty"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atomic_float = "1.1.0"
 clap = { version = "4.5.16", features = ["derive"] }
 clap-stdin = { version = "0.5.1", features = ["tokio"] }
 futures = "0.3.30"

--- a/src/bin/gn.rs
+++ b/src/bin/gn.rs
@@ -72,8 +72,7 @@ async fn main() -> gn::Result<()> {
         } => {
             let opts = WriteOptions::from_flags(count, duration, concurrency);
             let statistics = Statistics::new();
-            let mut manager =
-                SocketManager::new(host, input.as_bytes(), protocol, opts, statistics);
+            let manager = SocketManager::new(host, input.as_bytes(), protocol, opts, statistics);
             manager.write().await?;
 
             if stats {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -344,7 +344,7 @@ mod test {
             #[tokio::test]
             async fn $name() {
                 let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-                let mut s = SocketManager::new(
+                let s = SocketManager::new(
                     listener.local_addr().unwrap(),
                     $input,
                     $protocol,
@@ -460,7 +460,7 @@ mod test {
 
         for protocol in protocols {
             let addr = bind_socket(&protocol).await;
-            let mut s = SocketManager::new(
+            let s = SocketManager::new(
                 addr,
                 input,
                 protocol.clone(),
@@ -482,7 +482,7 @@ mod test {
         for protocol in protocols {
             let addr = bind_socket(&protocol).await;
             let input = b"c";
-            let mut s = SocketManager::new(
+            let s = SocketManager::new(
                 addr,
                 input,
                 protocol.clone(),
@@ -501,7 +501,7 @@ mod test {
         for protocol in protocols {
             let addr = bind_socket(&protocol).await;
             let duration = humantime::Duration::from_str("2s").unwrap();
-            let mut s = SocketManager::new(
+            let s = SocketManager::new(
                 addr,
                 input,
                 protocol.clone(),
@@ -524,7 +524,7 @@ mod test {
 
     async fn throughput_helper(protocol: Protocol) {
         let addr = bind_socket(&protocol).await;
-        let mut s = SocketManager::new(
+        let s = SocketManager::new(
             addr,
             b"a",
             protocol.clone(),

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -547,13 +547,7 @@ mod test {
 
         let start = Instant::now();
         let stats = Statistics::default();
-        let predicate = || {
-            if start.elapsed() > *duration {
-                true
-            } else {
-                false
-            }
-        };
+        let predicate = || start.elapsed() >* duration;
         write_stream_for_duration(predicate, addr, &protocol, b"test", &stats)
             .await
             .unwrap();

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -225,6 +225,12 @@ where
     }
 }
 
+/// Utility function for writing to a stream for a particular duration, as long
+/// as the predicate remains unfulfilled. The predicate is the break condition
+/// for the continuous writes to occur.
+///
+/// For example, passing a predicate of `|| true` means that the loop instantly
+/// breaks and no writes occur.
 async fn write_stream_for_duration<P>(
     mut predicate: P,
     addr: SocketAddr,

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,11 +1,15 @@
-use std::time::Instant;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::{sync::atomic::AtomicU64, time::Instant};
+
+use atomic_float::AtomicF64;
 
 pub struct Statistics {
     start_time: Instant,
-    total_bytes: u64,
-    success_count: u64,
-    failure_count: u64,
-    throughput: f64,
+    total_bytes: Arc<AtomicU64>,
+    success_count: Arc<AtomicU64>,
+    failure_count: Arc<AtomicU64>,
+    throughput: Arc<AtomicF64>,
 }
 
 impl Default for Statistics {
@@ -18,44 +22,47 @@ impl Statistics {
     pub fn new() -> Self {
         Self {
             start_time: Instant::now(),
-            total_bytes: 0,
-            success_count: 0,
-            failure_count: 0,
-            throughput: 0.0,
+            total_bytes: Arc::new(AtomicU64::new(0)),
+            success_count: Arc::new(AtomicU64::new(0)),
+            failure_count: Arc::new(AtomicU64::new(0)),
+            throughput: Arc::new(AtomicF64::new(0.0)),
         }
     }
 
     /// Increment the total number of bytes written
-    pub fn increment_total(&mut self, inc: u64) {
-        self.total_bytes += inc
+    pub fn increment_total(&self, inc: u64) {
+        self.total_bytes.fetch_add(inc, Ordering::Release);
     }
 
     /// Increment the number of successful requests
-    pub fn record_success(&mut self) {
-        self.success_count += 1;
+    pub fn record_success(&self) {
+        self.success_count.fetch_add(1, Ordering::Release);
     }
 
     /// Increment the number of failed requests
     pub fn record_failure(&mut self) {
-        self.failure_count += 1;
+        self.failure_count.fetch_add(1, Ordering::Release);
     }
 
     pub fn successful_requests(&self) -> u64 {
-        self.success_count
+        self.success_count.load(Ordering::Relaxed)
     }
 
     pub fn success_percentage(&self) -> f64 {
-        (self.success_count as f64 / (self.success_count + self.failure_count) as f64) * 100.0
+        let success = self.success_count.load(Ordering::Acquire) as f64;
+        let failure = self.failure_count.load(Ordering::Relaxed) as f64;
+
+        (success / (success + failure)) * 100.0
     }
 
     /// Get the total number of bytes written
     pub fn total_bytes(&self) -> u64 {
-        self.total_bytes
+        self.total_bytes.load(Ordering::Acquire)
     }
 
     /// Get the total number of sent requests.
     pub fn request_count(&self) -> u64 {
-        self.success_count + self.failure_count
+        self.success_count.load(Ordering::Acquire) + self.failure_count.load(Ordering::Relaxed)
     }
 
     /// Retrieve the perceived bytes per second throughput that was written to
@@ -64,7 +71,9 @@ impl Statistics {
     /// NOTE: Owing to truncation from nanosecond precision to seconds, the
     /// produced throughput may not be accurate for low write counts.
     pub fn record_throughput(&mut self) {
-        self.throughput = self.total_bytes as f64 / self.start_time.elapsed().as_secs() as f64;
+        let throughput = self.total_bytes.load(Ordering::Acquire) as f64
+            / self.start_time.elapsed().as_secs() as f64;
+        self.throughput.store(throughput, Ordering::Relaxed);
     }
 
     pub fn elapsed(&self) -> u128 {
@@ -73,7 +82,7 @@ impl Statistics {
 
     /// Return the recorded throughput
     pub fn throughput(&self) -> f64 {
-        self.throughput
+        self.throughput.load(Ordering::Acquire)
     }
 }
 

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -94,7 +94,7 @@ mod test {
 
     #[test]
     fn general() {
-        let mut stats = Statistics::new();
+        let stats = Statistics::new();
         assert_eq!(stats.total_bytes(), 0);
         assert_eq!(stats.successful_requests(), 0);
         assert_eq!(stats.failure_count.load(Ordering::Acquire), 0);


### PR DESCRIPTION
The main change here is the introduction of the `write_stream_with_predicate` function, which is used for continuously writing to a remote socket based on the evaluation of the passed predicate. At the moment, this is entirely used for duration purposes.

This PR also includes a few extra utility/type changes to remove mutable references by introducing atomics within the `Statistics`, based similar behaviour within the [Prometheus metrics counters](https://docs.rs/prometheus/latest/prometheus/core/struct.GenericCounter.html).